### PR TITLE
feat: add maxStreams to settings and overlay

### DIFF
--- a/src/components/overlay.tsx
+++ b/src/components/overlay.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import config from "@/config";
+import { useSettings } from "@/providers/settings.provider";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
 import { Button } from "./ui/button";
-import { Checkbox } from "./ui/checkbox";
 import { Label } from "./ui/label";
 import {
   Sheet,
@@ -11,23 +13,23 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "./ui/sheet";
-import { useSettings } from "@/providers/settings.provider";
-import { useForm } from "react-hook-form";
-import { useEffect } from "react";
+import { ToggleGroup, ToggleGroupItem } from "./ui/toggle-group";
 
 export const Overlay = () => {
-  const { languages, setLanguages, shown, setShown } = useSettings();
+  const { languages, setLanguages, shown, setShown, maxStreams, setMaxStreams } = useSettings();
 
-  const { register, watch } = useForm({
+  const { register, watch, setValue } = useForm({
     defaultValues: {
       languages,
       shown,
+      maxStreams
     },
     mode: "onChange",
   });
 
   const languagesWatcher = watch("languages");
   const shownWatcher = watch("shown");
+  const maxStreamsWatcher = watch("maxStreams");
 
   useEffect(() => {
     setLanguages(languagesWatcher);
@@ -36,6 +38,10 @@ export const Overlay = () => {
   useEffect(() => {
     setShown(shownWatcher);
   }, [shownWatcher, setShown]);
+
+  useEffect(() => {
+    setMaxStreams(maxStreamsWatcher);
+  }, [maxStreamsWatcher, setMaxStreams]);
 
   return (
     <div className="w-screen fixed top-0 left-0 flex justify-end items-center p-4 z-50">
@@ -90,6 +96,23 @@ export const Overlay = () => {
                       </Label>
                     </div>
                   ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="font-lg font-bold mb-3">Max streams</div>
+              <div className="flex flex-col gap-y-2">
+                <ToggleGroup
+                  type="single"
+                  className="justify-normal"
+                  value={maxStreamsWatcher.toString()}
+                  onValueChange={(value) => setValue('maxStreams', Number(value))}
+                >
+                  <ToggleGroupItem value="6">6</ToggleGroupItem>
+                  <ToggleGroupItem value="9">9</ToggleGroupItem>
+                  <ToggleGroupItem value="12">12</ToggleGroupItem>
+                  <ToggleGroupItem value="0">All</ToggleGroupItem>
+                </ToggleGroup>
               </div>
             </div>
           </form>

--- a/src/providers/settings.provider.tsx
+++ b/src/providers/settings.provider.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { StreamerData } from "@/lib/api";
 import { ReactNode, createContext, useContext, useMemo, useState } from "react";
 import { useStreamers } from "./streamers.provider";
-import { StreamerData } from "@/lib/api";
 
 type SettingsState = {
   languages: string[];
@@ -10,6 +10,8 @@ type SettingsState = {
   shown: string[];
   setShown: (shown: string[]) => void;
   shownStreamers: StreamerData[];
+  maxStreams: number,
+  setMaxStreams: (maxStreams: number) => void
 };
 
 const SettingsContext = createContext<SettingsState | null>(null);
@@ -22,12 +24,13 @@ export const SettingsProvider = ({ children }: SettingsProviderProps) => {
   const { streamers } = useStreamers();
 
   const [languages, setLanguages] = useState<string[]>([]);
+  const [maxStreams, setMaxStreams] = useState<number>(9);
   const [shown, setShown] = useState<string[]>(
     streamers.map((s) => s.streamer.twitch),
   );
 
   const shownStreamers = useMemo(() => {
-    let shownStreamers = streamers.filter((s) => s.online);
+    let shownStreamers = streamers.filter((s) => s.online).splice(0, maxStreams || 9);
 
     if (languages.length) {
       shownStreamers = shownStreamers.filter((s) =>
@@ -44,7 +47,7 @@ export const SettingsProvider = ({ children }: SettingsProviderProps) => {
     );
 
     return shownStreamers;
-  }, [languages, streamers, shown]);
+  }, [languages, streamers, shown, maxStreams]);
 
   return (
     <SettingsContext.Provider
@@ -54,6 +57,8 @@ export const SettingsProvider = ({ children }: SettingsProviderProps) => {
         shownStreamers,
         shown,
         setShown,
+        maxStreams,
+        setMaxStreams
       }}
     >
       {children}


### PR DESCRIPTION
Thank you for creating this! Was planning on doing something similar but thankfully found your first 😅

Added "Max Streamers" to the settings and overlay. Options provided are: 6, 9, 12, All
Should preferably be persisted in the browser, as with all other settings.

![image](https://github.com/kerwanp/deepdip.tv/assets/33940473/5e547f30-24d8-435d-aae9-dbd7c9ee5f0e)
