### PR TITLE
on widescreen and to many streamers need to scroll settings

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed overflow-auto z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {


### PR DESCRIPTION
Enabling scroll for settings side panel "Sheet" tested locally.

Before: 
<img src="https://github.com/kerwanp/deepdip.tv/assets/945619/1d806b9e-b816-4a32-993b-ddded95526d4" width="170" height="280" />

After:
<img src="https://github.com/kerwanp/deepdip.tv/assets/945619/8bd43835-2541-43a0-ba6c-61b6d5126756" width="170" height="280" />
